### PR TITLE
sceneDelegate 경량화 & DecodeManager 분리

### DIFF
--- a/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		2DF2770E9554CFA7A43BF1F6 /* Pods_IssueTracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 723F045752A9006DEAC1B352 /* Pods_IssueTracker.framework */; };
 		B3419D33285C1EC800F1273C /* LoginRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3419D32285C1EC800F1273C /* LoginRepository.swift */; };
 		B3419D35285C205600F1273C /* RequestRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3419D34285C205600F1273C /* RequestRepository.swift */; };
+		B3419D37285C30EB00F1273C /* IssueTrackingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3419D36285C30EB00F1273C /* IssueTrackingRepository.swift */; };
 		B3773F282858518A008C4AAF /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3773F272858518A008C4AAF /* Issue.swift */; };
 		B3773F2A28585216008C4AAF /* Milestone.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3773F2928585216008C4AAF /* Milestone.swift */; };
 		B3773F2E28585237008C4AAF /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3773F2D28585237008C4AAF /* Tag.swift */; };
@@ -61,6 +62,7 @@
 		907546187A5C5236FB655944 /* Pods-IssueTracker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.release.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.release.xcconfig"; sourceTree = "<group>"; };
 		B3419D32285C1EC800F1273C /* LoginRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRepository.swift; sourceTree = "<group>"; };
 		B3419D34285C205600F1273C /* RequestRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestRepository.swift; sourceTree = "<group>"; };
+		B3419D36285C30EB00F1273C /* IssueTrackingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueTrackingRepository.swift; sourceTree = "<group>"; };
 		B3773F272858518A008C4AAF /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
 		B3773F2928585216008C4AAF /* Milestone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Milestone.swift; sourceTree = "<group>"; };
 		B3773F2D28585237008C4AAF /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 			children = (
 				B3419D32285C1EC800F1273C /* LoginRepository.swift */,
 				B3419D34285C205600F1273C /* RequestRepository.swift */,
+				B3419D36285C30EB00F1273C /* IssueTrackingRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 				000651C1285A0A9C00A6426A /* NetworkError.swift in Sources */,
 				B3773F75285B1990008C4AAF /* HTTPAcceptType.swift in Sources */,
 				B3419D35285C205600F1273C /* RequestRepository.swift in Sources */,
+				B3419D37285C30EB00F1273C /* IssueTrackingRepository.swift in Sources */,
 				B3773F3928586D97008C4AAF /* IssueCell.swift in Sources */,
 				B3773F2A28585216008C4AAF /* Milestone.swift in Sources */,
 				000651C5285A0B7500A6426A /* HTTPContentType.swift in Sources */,
@@ -459,7 +463,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -483,7 +487,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		00B2A26928586D0600D201D3 /* Issue.json in Resources */ = {isa = PBXBuildFile; fileRef = 00B2A26828586D0600D201D3 /* Issue.json */; };
 		00B2A27128586F9D00D201D3 /* MockIssueTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B2A27028586F9D00D201D3 /* MockIssueTest.swift */; };
 		2DF2770E9554CFA7A43BF1F6 /* Pods_IssueTracker.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 723F045752A9006DEAC1B352 /* Pods_IssueTracker.framework */; };
+		B3419D33285C1EC800F1273C /* LoginRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3419D32285C1EC800F1273C /* LoginRepository.swift */; };
+		B3419D35285C205600F1273C /* RequestRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3419D34285C205600F1273C /* RequestRepository.swift */; };
 		B3773F282858518A008C4AAF /* Issue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3773F272858518A008C4AAF /* Issue.swift */; };
 		B3773F2A28585216008C4AAF /* Milestone.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3773F2928585216008C4AAF /* Milestone.swift */; };
 		B3773F2E28585237008C4AAF /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3773F2D28585237008C4AAF /* Tag.swift */; };
@@ -57,6 +59,8 @@
 		367146F3B09437CB1929CCDA /* Pods-IssueTracker.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.debug.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.debug.xcconfig"; sourceTree = "<group>"; };
 		723F045752A9006DEAC1B352 /* Pods_IssueTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IssueTracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		907546187A5C5236FB655944 /* Pods-IssueTracker.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IssueTracker.release.xcconfig"; path = "Target Support Files/Pods-IssueTracker/Pods-IssueTracker.release.xcconfig"; sourceTree = "<group>"; };
+		B3419D32285C1EC800F1273C /* LoginRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRepository.swift; sourceTree = "<group>"; };
+		B3419D34285C205600F1273C /* RequestRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestRepository.swift; sourceTree = "<group>"; };
 		B3773F272858518A008C4AAF /* Issue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Issue.swift; sourceTree = "<group>"; };
 		B3773F2928585216008C4AAF /* Milestone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Milestone.swift; sourceTree = "<group>"; };
 		B3773F2D28585237008C4AAF /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
@@ -153,6 +157,15 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		B3419D31285C1E3300F1273C /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+				B3419D32285C1EC800F1273C /* LoginRepository.swift */,
+				B3419D34285C205600F1273C /* RequestRepository.swift */,
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
 		B3773F2428585143008C4AAF /* Source */ = {
 			isa = PBXGroup;
 			children = (
@@ -187,6 +200,7 @@
 		B3773F3128585624008C4AAF /* Resource */ = {
 			isa = PBXGroup;
 			children = (
+				B3419D31285C1E3300F1273C /* Repository */,
 				00B2A26528585CE200D201D3 /* API */,
 				00B2A26828586D0600D201D3 /* Issue.json */,
 			);
@@ -407,6 +421,7 @@
 				B3773F37285864E2008C4AAF /* IssueListViewController.swift in Sources */,
 				B3BFBD3628572E5400D69A34 /* AppDelegate.swift in Sources */,
 				B3773F2E28585237008C4AAF /* Tag.swift in Sources */,
+				B3419D33285C1EC800F1273C /* LoginRepository.swift in Sources */,
 				B3773F732859C607008C4AAF /* LoginManager.swift in Sources */,
 				00B2A267285867A400D201D3 /* IssueResponse.swift in Sources */,
 				000651BE285A09DE00A6426A /* IssueTrackerTarget.swift in Sources */,
@@ -414,6 +429,7 @@
 				000651C7285A0C0700A6426A /* BaseTarget.swift in Sources */,
 				000651C1285A0A9C00A6426A /* NetworkError.swift in Sources */,
 				B3773F75285B1990008C4AAF /* HTTPAcceptType.swift in Sources */,
+				B3419D35285C205600F1273C /* RequestRepository.swift in Sources */,
 				B3773F3928586D97008C4AAF /* IssueCell.swift in Sources */,
 				B3773F2A28585216008C4AAF /* Milestone.swift in Sources */,
 				000651C5285A0B7500A6426A /* HTTPContentType.swift in Sources */,

--- a/IssueTracker/IssueTracker/Resource/API/LoginManager.swift
+++ b/IssueTracker/IssueTracker/Resource/API/LoginManager.swift
@@ -10,19 +10,4 @@ import UIKit
 
 class LoginManager {
 
-    static func requestGithubAuthorize() {
-        let clientID = "e6386d0321b6dc2820c0"
-        let scope = "repo user"
-        let urlString = "https://github.com/login/oauth/authorize"
-        guard var components = URLComponents(string: urlString) else { return }
-        components.queryItems = [
-            URLQueryItem(name: "client_id", value: clientID),
-            URLQueryItem(name: "scope", value: scope)
-        ]
-        print(components.url!)
-
-        guard let url = URL(string: "\(components.url!)"), UIApplication.shared.canOpenURL(url) else { return }
-
-        UIApplication.shared.open(url)
-    }
 }

--- a/IssueTracker/IssueTracker/Resource/Repository/IssueTrackingRepository.swift
+++ b/IssueTracker/IssueTracker/Resource/Repository/IssueTrackingRepository.swift
@@ -33,7 +33,6 @@ class IssueTrackingRepository {
                    let response = response as? HTTPURLResponse,
                    response.statusCode == 200 {
                     guard let issueResponse: IssueResponse = DecodeManagerImplement.decodeJson(data: data) else { return }
-//                    let issueResponse = try JSONDecoder().decode(IssueResponse.self, from: data)
                     result = issueResponse.body
                 }
             } catch {
@@ -56,7 +55,6 @@ class IssueTrackingRepository {
         do {
             let jsonData = try Data(contentsOf: fileLocation)
             guard let issueList: IssueResponse = DecodeManagerImplement.decodeJson(data: jsonData) else { return nil }
-//            let issueList = try JSONDecoder().decode(IssueResponse.self, from: jsonData)
             return issueList.body
         } catch {
             // TODO: - error 처리

--- a/IssueTracker/IssueTracker/Resource/Repository/IssueTrackingRepository.swift
+++ b/IssueTracker/IssueTracker/Resource/Repository/IssueTrackingRepository.swift
@@ -1,0 +1,66 @@
+//
+//  IssueTrackingRepository.swift
+//  IssueTracker
+//
+//  Created by 최예주 on 2022/06/17.
+//
+
+import Foundation
+
+protocol IssueTracking {
+    func requestIssues(url: String, completion: @escaping (Result<[Issue]?, NetworkError>) -> Void )
+    func getIssuesOnFailure() -> [Issue]?
+}
+
+class IssueTrackingRepository {
+
+    func requestIssues(url: String,
+                       completion: @escaping (Result<[Issue]?, NetworkError>) -> Void) {
+        guard let requestURL = URL(string: url) else {
+            return completion(.failure(.invalidUrlError))
+        }
+        var result: [Issue] = []
+        let session = URLSession.shared
+
+        session.dataTask(with: requestURL) {
+            data, response, error in
+            do {
+                guard error == nil else {
+                    return completion(.failure(.cantReachedServerError))
+                }
+
+                if let data = data,
+                   let response = response as? HTTPURLResponse,
+                   response.statusCode == 200 {
+                    guard let issueResponse: IssueResponse = DecodeManagerImplement.decodeJson(data: data) else { return }
+//                    let issueResponse = try JSONDecoder().decode(IssueResponse.self, from: data)
+                    result = issueResponse.body
+                }
+            } catch {
+                completion(.failure(.invalidJsonError))
+            }
+        }
+
+        return completion(.success(result))
+    }
+    // MARK: - Local에 JSON 파일로 [Issue] 를 로딩
+    func getIssuesOnFailure() -> [Issue]? {
+        let fileName: String = "Issue"
+        let extensionType = "json"
+
+        guard let fileLocation = Bundle.main.url(
+            forResource: fileName,
+            withExtension: extensionType
+        ) else { return nil }
+
+        do {
+            let jsonData = try Data(contentsOf: fileLocation)
+            guard let issueList: IssueResponse = DecodeManagerImplement.decodeJson(data: jsonData) else { return nil }
+//            let issueList = try JSONDecoder().decode(IssueResponse.self, from: jsonData)
+            return issueList.body
+        } catch {
+            // TODO: - error 처리
+            return nil
+        }
+    }
+}

--- a/IssueTracker/IssueTracker/Resource/Repository/LoginRepository.swift
+++ b/IssueTracker/IssueTracker/Resource/Repository/LoginRepository.swift
@@ -1,0 +1,38 @@
+//
+//  LoginRepository.swift
+//  IssueTracker
+//
+//  Created by 최예주 on 2022/06/17.
+//
+
+import Foundation
+import UIKit
+
+class LoginRepository {
+
+    func requestGithubAuthorize() {
+        let clientID = "e6386d0321b6dc2820c0"
+        let scope = "repo user"
+        let urlString = "https://github.com/login/oauth/authorize"
+        guard var components = URLComponents(string: urlString) else { return }
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "scope", value: scope)
+        ]
+        guard let url = URL(string: "\(components.url!)"), UIApplication.shared.canOpenURL(url) else { return }
+
+        UIApplication.shared.open(url)
+    }
+
+    func getGithubAccessCode(_ target: BaseTarget, _ completion: @escaping (String) -> Void) {
+
+        guard let request = RequestRepository.makeURLRequest(with: target) else { return }
+        RequestRepository.sendRequest(with: request) { data in
+            guard let jsonData = try! JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+
+            guard let access_token = jsonData["access_token"] as? String else { return }
+            completion(access_token)
+        }
+    }
+
+}

--- a/IssueTracker/IssueTracker/Resource/Repository/RequestRepository.swift
+++ b/IssueTracker/IssueTracker/Resource/Repository/RequestRepository.swift
@@ -1,0 +1,45 @@
+//
+//  RequestRepository.swift
+//  IssueTracker
+//
+//  Created by 최예주 on 2022/06/17.
+//
+
+import Foundation
+
+class RequestRepository {
+
+    static func sendRequest(with request: URLRequest, _ completion: @escaping (Data) -> Void) {
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                print(error.localizedDescription)
+                return
+            }
+            guard let httpResponse = response as? HTTPURLResponse, (200..<300).contains(httpResponse.statusCode) else {
+                  return
+              }
+            guard let data = data else { return }
+            completion(data)
+        }.resume()
+    }
+
+    static func makeURLRequest(with target: BaseTarget) -> URLRequest? {
+        guard var url = target.baseURL else { return nil }
+        if let path = target.path {
+            url = url.appendingPathComponent(path)
+        }
+        var request = URLRequest(url: url)
+
+        if let param = target.parameter {
+            let requestBody = try! JSONSerialization.data(withJSONObject: param, options: .init())
+            request.httpBody = requestBody
+        }
+        request.setValue(target.content.value, forHTTPHeaderField: target.content.forHTTPHeaderField)
+        if let accept = target.accept {
+            request.addValue(accept.value, forHTTPHeaderField: accept.forHTTPHeaderField)
+        }
+        request.httpMethod = target.method.value
+
+        return request
+    }
+}

--- a/IssueTracker/IssueTracker/Source/Support/SceneDelegate.swift
+++ b/IssueTracker/IssueTracker/Source/Support/SceneDelegate.swift
@@ -15,71 +15,28 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
 
-        
-        //TODO: Access token 유효성 검사 후 화면 흐름 제어하기
+        // TODO: Access token 유효성 검사 후 화면 흐름 제어하기
 
         window?.rootViewController = ViewController()
         window?.makeKeyAndVisible()
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        // Authorized code
+
+        let loginRepository = LoginRepository()
+
         guard let response = URLContexts.first?.url,
         let authorizedCode = response.absoluteString.components(separatedBy: "code=").last else { return }
-        let targetUrl: IssueTrackerTarget = .requestAccessToken(code: authorizedCode)
-        print(targetUrl)
 
-        // authorizedCode를 넣은 IssueTarget생성
-        // 얘로 validURL을 만들어서 POST 요청을 보내야함
         let target = IssueTrackerTarget.requestAccessToken(code: authorizedCode)
 
-        guard let requestURL = createRequest(target) else { return }
-
-        URLSession.shared.dataTask(with: requestURL) { data, _, error in
-
-            guard error == nil else { return }
-            guard let data = data else { return }
-            guard let jsonData = try! JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
-
-            //TODO: access Token 저장 방식 변경
-            UserDefaults.standard.set("access_token", forKey: jsonData["access_token"] as! String)
-            
+        loginRepository.getGithubAccessCode(target) { token in
+            UserDefaults.standard.set("access_token", forKey: token)
             DispatchQueue.main.async {
                 self.window?.rootViewController = TabBarViewController()
             }
-
-        }.resume()
-
-    }
-
-    private func createRequest(_ target: BaseTarget) -> URLRequest? {
-        // base url
-        guard var url = target.baseURL else {
-            return nil
-        }
-        // parameter append
-        if let path = target.path {
-            url = url.appendingPathComponent(path)
-        }
-        var request = URLRequest(url: url)
-
-        // paramter를 Json으로 encode
-        if let param = target.parameter {
-            let requestBody = try! JSONSerialization.data(withJSONObject: target.parameter!, options: .init())
-            request.httpBody = requestBody
         }
 
-        // 우리가 전송하는 헤더의 타입 설정
-        request.setValue(target.content.value, forHTTPHeaderField: target.content.forHTTPHeaderField)
-
-        // 응답으로 받아오는 data 의 타입 설정
-        if let accept = target.accept {
-            request.addValue(accept.value, forHTTPHeaderField: accept.forHTTPHeaderField)
-        }
-
-        request.httpMethod = target.method.value
-
-        return request
     }
 
 }

--- a/IssueTracker/IssueTracker/Source/Support/ViewController.swift
+++ b/IssueTracker/IssueTracker/Source/Support/ViewController.swift
@@ -10,11 +10,14 @@ import SnapKit
 
 class ViewController: UIViewController {
 
-    private let githubLoginButton: UIButton = {
+    // TODO: 후에 LoginViewModel 에서 요청하도록 변경
+    let loginRepository = LoginRepository()
+
+    private lazy var githubLoginButton: UIButton = {
         let button = UIButton()
         button.setTitle("gitbutton", for: .normal)
         button.addAction(UIAction(handler: { _ in
-            LoginManager.requestGithubAuthorize()
+            self.loginRepository.requestGithubAuthorize()
         }), for: .touchUpInside)
         return button
     }()

--- a/IssueTracker/MockIssueTest/MockIssueTest.swift
+++ b/IssueTracker/MockIssueTest/MockIssueTest.swift
@@ -10,11 +10,13 @@ import XCTest
 @testable import IssueTracker
 
 class MockIssueTest: XCTestCase {
-    var manager: DecodeManager!
+
+    var issueRepository: IssueTrackingRepository!
 
     func testLocalMockIssues() throws {
-        manager = DecodeManagerImplement()
-        let issues = manager.getIssuesOnFailure()
+//        manager = DecodeManagerImplement()
+        issueRepository = IssueTrackingRepository()
+        let issues = issueRepository.getIssuesOnFailure()
 
         XCTAssertNotNil(issues, "Issue is NIL")
     }


### PR DESCRIPTION
- LoginRepository, IssueTrackingRepository 를 구현해서 sceneDelegate에서 처리하는 로직을 분리 
- Decode 메소드 구현  & DecodeManager 기존 메소드 -> IssueTrackingRepository로 이전 